### PR TITLE
added missing callbacks and refactoring

### DIFF
--- a/Sources/swift-ads-package/swift_ads_package.swift
+++ b/Sources/swift-ads-package/swift_ads_package.swift
@@ -7,24 +7,64 @@ import Combine
 
 @available(iOS 13.0, *)
 @objc public class SwiftAdsPackage: WKWebView {
-
+    
     private var finishedLoading: Bool = false;
     private var scriptId: Int
     private var cancellables = Set<AnyCancellable>()
     private let counterStorage = CounterStorage()
-    private var onError: (() -> Void)?
-    private var alternative: (() -> Void)?
- 
-
+    
+    // Triggered when an error occurs during the WebView's operation, such as failing to load content.
+    // This is called if the banner does not exist in the WebView.
+    private var onErrorCallback: (() -> Void)?
+    
+    // Triggered when an alternative action is needed, such as displaying a fallback banner or alternative content.
+    // This is called if the banner does not exist in the WebView.
+    private var onAlternativeCallback: (() -> Void)?
+    
+    // Triggered when a custom data callback is executed by the JavaScript running in the WebView.
+    // This is called if the banner exists in the WebView.
+    private var onDataCallback: (() -> Void)?
+    
+    // Triggered when a user clicks on a specific element in the WebView that activates the "data-callback-url-click" event.
+    private var onDataUrlClickCallback: (() -> Void)?
+    
+    // Triggered when a view-related event occurs in the WebView, associated with the "data-callback-url-view" event.
+    private var onDataUrlViewCallback: (() -> Void)?
+    
+    // Triggered when the WebView finishes loading its content.
+    // The parameter indicates whether an iframe was detected in the loaded content, which can help verify if the banner is successfully loaded.
+    // Note: Detecting an iframe is not an official method to confirm banner loading, but it can be used as a supplementary check
+    // alongside onDataCallback, onAlternativeCallback, onErrorCallback, and onDestroyCallback.
+    private var onFinishedLoadingCallback: ((Bool) -> Void)?
+    
+    // Triggered when the WebView is destroyed, such as when it is removed from the view hierarchy or no longer needed.
+    private var onDestroyCallback: (() -> Void)?
+    
     // New initializer with the custom integer parameter
-    @objc public init(frame: CGRect, configuration: WKWebViewConfiguration, scriptId: Int, onError: (() -> Void)? = nil, alternative: (() -> Void)? = nil) {
+    @objc public init(
+        frame: CGRect,
+        configuration: WKWebViewConfiguration,
+        scriptId: Int,
+        onErrorCallback: (() -> Void)? = nil,
+        onAlternativeCallback: (() -> Void)? = nil,
+        onDataCallback: (() -> Void)? = nil,
+        onDataUrlClickCallback: (() -> Void)? = nil,
+        onDataUrlViewCallback: (() -> Void)? = nil,
+        onFinishedLoadingCallback: ((Bool) -> Void)? = nil,
+        onDestroyCallback: (() -> Void)? = nil
+    ) {
         self.scriptId = scriptId
-        self.onError = onError
-        self.alternative = alternative
+        self.onErrorCallback = onErrorCallback
+        self.onAlternativeCallback = onAlternativeCallback
+        self.onDataCallback = onDataCallback
+        self.onDataUrlClickCallback = onDataUrlClickCallback
+        self.onDataUrlViewCallback = onDataUrlViewCallback
+        self.onFinishedLoadingCallback = onFinishedLoadingCallback
+        self.onDestroyCallback = onDestroyCallback
         super.init(frame: frame, configuration: configuration)
         setup()
     }
-
+    
     // Overriding the existing initializer
     public override init(frame: CGRect, configuration: WKWebViewConfiguration) {
         self.scriptId = 0 // Provide a default value if needed
@@ -41,17 +81,17 @@ import Combine
         print("Checking counter data")
         print("chega interno:")
         counterStorage.getCounterData(scriptId: "\(scriptId)")
-                    .receive(on: DispatchQueue.main)
-                    .sink(receiveCompletion: { _ in }) { [weak self] result in
-                        if result != false {
-                            print("Counter data existed, leaving")
-                            self?.destroy()
-                        } else {
-                            print("Initialize webview")
-                            self?.initWebView()
-                        }
-                    }
-                    .store(in: &cancellables)
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { _ in }) { [weak self] result in
+                if result != false {
+                    print("Counter data existed, leaving")
+                    self?.destroy()
+                } else {
+                    print("Initialize webview")
+                    self?.initWebView()
+                }
+            }
+            .store(in: &cancellables)
     }
     
     private func initWebView() {
@@ -61,7 +101,7 @@ import Combine
         
         // Configure WebView settings
         let scriptUrl = "https://script.cleverwebserver.com/v1/html/\(scriptId)?app=\(Bundle.main.bundleIdentifier ?? "")&sdk=swift"
-
+        
         let request = URLRequest(url: URL(string: scriptUrl)!)
         self.load(request)
         
@@ -75,9 +115,38 @@ import Combine
                 oldPostMessage(message);
             };
             """
-            let userScript = WKUserScript(source: js, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
-            self.configuration.userContentController.addUserScript(userScript)
-
+        let userScript = WKUserScript(source: js, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
+        self.configuration.userContentController.addUserScript(userScript)
+        
+        let callbackJs = """
+               (function() {
+                   let script = document.getElementById('CleverCoreLoader\(scriptId)');
+                   if (script) {
+                       script.setAttribute('data-callback', 'dataCallbackFunction');
+                       script.setAttribute('data-callback-url-click', 'dataUrlClickFunction');
+                       script.setAttribute('data-callback-url-view', 'dataUrlViewFunction');
+           
+                       window.dataCallbackFunction = function() {
+                           window.webkit.messageHandlers.SwiftAdsMessageHandler.postMessage('data-callback');
+                       };
+           
+                       window.dataUrlClickFunction = function() {
+                           window.webkit.messageHandlers.SwiftAdsMessageHandler.postMessage('data-callback-url-click');
+                       };
+           
+                       window.dataUrlViewFunction = function() {
+                           window.webkit.messageHandlers.SwiftAdsMessageHandler.postMessage('data-callback-url-view');
+                       };
+           
+                       console.log('Custom callbacks and attributes injected');
+                   } else {
+                       console.log('Script element not found');
+                   }
+               })();
+           """
+        let callbackUserScript = WKUserScript(source: callbackJs, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
+        self.configuration.userContentController.addUserScript(callbackUserScript)
+        
         let lastTrackerCookieKey = "clever-last-tracker-\(self.scriptId)"
         let lastTracker = self.counterStorage.getFromStorage(key: lastTrackerCookieKey);
         if let lastTracker = lastTracker {
@@ -88,7 +157,7 @@ import Combine
                 .secure: "TRUE",
                 .expires: NSDate(timeIntervalSinceNow: 2.628e+6)
             ]
-
+            
             if let cookie = HTTPCookie(properties: cookieProperties) {
                 // Add the cookie to the web view
                 let websiteDataStore = WKWebsiteDataStore.default()
@@ -96,44 +165,45 @@ import Combine
             }
         }
         //self.configuration.preferences.setValue(true, forKey: "domStorageEnabled")
-        
     }
+    
     private func destroy() {
-            self.navigationDelegate = nil
-            self.uiDelegate = nil
-            self.stopLoading()
-            self.removeFromSuperview()
-            self.load(URLRequest(url: URL(string: "about:blank")!))
-        }
+        self.navigationDelegate = nil
+        self.uiDelegate = nil
+        self.stopLoading()
+        self.removeFromSuperview()
+        self.load(URLRequest(url: URL(string: "about:blank")!))
+        self.onDestroyCallback?()
+    }
 }
 @available(iOS 13.0, *)
 extension SwiftAdsPackage: WKNavigationDelegate, WKUIDelegate {
     public func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
         if navigationAction.targetFrame == nil {
-            #if os(iOS)
+#if os(iOS)
             UIApplication.shared.open(navigationAction.request.url!, options: [:])
-            #elseif os(macOS)
+#elseif os(macOS)
             NSWorkspace.shared.open(navigationAction.request.url!)
-            #endif
+#endif
         }
         return nil
     }
     // WKNavigationDelegate methods
     public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
         // Check if the URL is intended to be opened in an external browser
-            if (!finishedLoading) {
-                decisionHandler(.allow)
-                return;
-            }
+        if (!finishedLoading) {
+            decisionHandler(.allow)
+            return;
+        }
         
-            if shouldBeOpenedInBrowser(url: navigationAction.request.url?.absoluteString ?? "") {
+        if shouldBeOpenedInBrowser(url: navigationAction.request.url?.absoluteString ?? "") {
             // Intent to open link in the default browser
             if let url = navigationAction.request.url {
-                #if os(iOS)
+#if os(iOS)
                 UIApplication.shared.open(url)
-                #elseif os(macOS)
+#elseif os(macOS)
                 NSWorkspace.shared.open(url)
-                #endif
+#endif
             }
             decisionHandler(.cancel)
         } else {
@@ -143,7 +213,37 @@ extension SwiftAdsPackage: WKNavigationDelegate, WKUIDelegate {
     
     public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         self.finishedLoading = true;
-        let scriptUrl = "https://script.cleverwebserver.com/v1/html/\(scriptId)?app=\(Bundle.main.bundleIdentifier ?? "")&sdk=swift"
+        
+        // Check the WebView's HTML content
+        webView.evaluateJavaScript("document.documentElement.outerHTML") { result, error in
+            if let html = result as? String {
+                print("HTML Content: \(html)")
+            } else if let error = error {
+                print("Failed to retrieve HTML content: \(error.localizedDescription)")
+            }
+        }
+        
+        // Check if the page contains any <iframe> elements
+        let js = """
+                (function() {
+                    return document.getElementsByTagName('iframe').length > 0;
+                })();
+            """
+        
+        webView.evaluateJavaScript(js) { [weak self] result, error in
+            if let hasIframe = result as? Bool, hasIframe {
+                print("Iframe found on the page")
+                // Execute the callback to indicate that the banner is loaded
+                self?.onFinishedLoadingCallback?(true)
+            } else if let error = error {
+                print("Failed to check for iframes: \(error.localizedDescription)")
+                self?.onFinishedLoadingCallback?(false)
+            } else {
+                print("No iframe found on the page")
+                self?.onFinishedLoadingCallback?(false)
+            }
+        }
+        
         self.configuration.websiteDataStore.httpCookieStore.getAllCookies { cookies in
             for cookie in cookies {
                 let key = cookie.name
@@ -165,7 +265,7 @@ extension SwiftAdsPackage: WKNavigationDelegate, WKUIDelegate {
                 }
             }
         }
-
+        
     }
     
     // WKUIDelegate methods if needed
@@ -184,18 +284,37 @@ extension SwiftAdsPackage: WKScriptMessageHandler {
     public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         if message.name == "SwiftAdsMessageHandler", let messageBody = message.body as? String {
             let splittedMessage = messageBody.split(separator: "|")
-            if(splittedMessage.first == "clever-redirect") {
-                #if os(iOS)
+            if (splittedMessage.first == "clever-redirect") {
+#if os(iOS)
                 if let urlString = splittedMessage.last.map(String.init), let url = URL(string: urlString), UIApplication.shared.canOpenURL(url) {
                     UIApplication.shared.open(url, options: [:], completionHandler: nil)
                 }
-                #endif
+#endif
             }
-            if(splittedMessage.last == "callback") {   
-                self.onError?()
+            
+            if (splittedMessage.last == "callback") {
+                print("callback triggered")
+                self.onErrorCallback?()
             }
-            if(splittedMessage.last == "alternative") {
-                self.alternative?()
+            
+            if (splittedMessage.last == "alternative") {
+                print("alternative triggered")
+                self.onAlternativeCallback?()
+            }
+            
+            if splittedMessage.last == "data-callback" {
+                print("data-callback triggered")
+                self.onDataCallback?()
+            }
+            
+            if splittedMessage.last == "data-callback-url-click" {
+                print("data-callback-url-click triggered")
+                self.onDataUrlClickCallback?()
+            }
+            
+            if splittedMessage.last == "data-callback-url-view" {
+                print("data-callback-url-view triggered")
+                self.onDataUrlViewCallback?()
             }
         }
     }


### PR DESCRIPTION
**Added new callbacks:**

```
    // Triggered when an error occurs during the WebView's operation, such as failing to load content.
    // This is called if the banner does not exist in the WebView.
    private var onErrorCallback: (() -> Void)?
    
    // Triggered when an alternative action is needed, such as displaying a fallback banner or alternative content.
    // This is called if the banner does not exist in the WebView.
    private var onAlternativeCallback: (() -> Void)?
    
    // Triggered when a custom data callback is executed by the JavaScript running in the WebView.
    // This is called if the banner exists in the WebView.
    private var onDataCallback: (() -> Void)?
    
    // Triggered when a user clicks on a specific element in the WebView that activates the "data-callback-url-click" event.
    private var onDataUrlClickCallback: (() -> Void)?
    
    // Triggered when a view-related event occurs in the WebView, associated with the "data-callback-url-view" event.
    private var onDataUrlViewCallback: (() -> Void)?
    
    // Triggered when the WebView finishes loading its content.
    // The parameter indicates whether an iframe was detected in the loaded content, which can help verify if the banner is successfully loaded.
    // Note: Detecting an iframe is not an official method to confirm banner loading, but it can be used as a supplementary check
    // alongside onDataCallback, onAlternativeCallback, onErrorCallback, and onDestroyCallback.
    private var onFinishedLoadingCallback: ((Bool) -> Void)?
    
    // Triggered when the WebView is destroyed, such as when it is removed from the view hierarchy or no longer needed.
    private var onDestroyCallback: (() -> Void)?


```

**Example of usage:**

```
- (BOOL)isMediumRectangleBannerSupported {
    return YES;
}

- (void)loadMediumRectangleBanner {
    LSWeakifySelf;
    self.mediumRectBannerLoading = YES;
    
    WKWebViewConfiguration *webViewConfiguration = [[WKWebViewConfiguration alloc] init];
    CGRect frame = CGRectMake(0.0, 0.0, self.mediumRectangleBannerSize.width, self.mediumRectangleBannerSize.height);
    
    SwiftAdsPackage *mediumRectBannerNativeView = [[SwiftAdsPackage alloc] initWithFrame:frame
                                                     configuration:webViewConfiguration
                                                          scriptId:APP_CLEVERADS_BANNER_SCRIPT_ID
                                                           onErrorCallback:^{
        NSLog(@"CleverAds medium_rect banner onErrorCallback");
        [weakSelf mediumRectBannerDidFailToLoad];
    } onAlternativeCallback:^{
        NSLog(@"CleverAds medium_rect banner onAlternativeCallback");
        [weakSelf mediumRectBannerDidFailToLoad];
    } onDataCallback:^{
        NSLog(@"CleverAds medium_rect banner onDataCallback");
        [weakSelf mediumRectBannerDidSuccessToLoad];
    } onDataUrlClickCallback:^{
        NSLog(@"CleverAds medium_rect banner onDataUrlClickCallback");
    } onDataUrlViewCallback:^{
        NSLog(@"CleverAds medium_rect banner onDataUrlViewCallback");
    } onFinishedLoadingCallback:^(BOOL bannerExists) {
        NSLog(@"CleverAds medium_rect banner onFinishedLoadingCallback, bannerExists: %@",@(bannerExists));
        if (bannerExists == NO) {
            [weakSelf mediumRectBannerDidFailToLoad];
        }
        else {
            [weakSelf mediumRectBannerDidSuccessToLoad];
        }
    } onDestroyCallback:^{
        NSLog(@"CleverAds medium_rect banner onDestroyCallback");
        [weakSelf mediumRectBannerDidFailToLoad];
    }];

    LSNativeBannerWrapperView *wrapper = [[LSNativeBannerWrapperView alloc] initWithFrame:frame];
    [wrapper addNativeAdsView:mediumRectBannerNativeView];
    [wrapper setNativeAdsViewDidRemovedHandler:^{
        //if native ad banner view removed
        //that mean error during medium rect banner load request
        //according to code in sdk
        [weakSelf mediumRectBannerDidFailToLoad];
    }];

    self.mediumRectBanner = wrapper;
}

- (void)mediumRectBannerDidFailToLoad {
    [NSObject ls_performBlockOnMainQueue:^{
        //noting to do and also avoid multiple delegate calls for one event
        if (self.mediumRectBannerLoading == NO) {
            return;
        }
        self.mediumRectBannerLoading = NO;
        
        [self unloadMediumRectangleBanner];
        NSError *error = [NSError errorWithDomain:@"LSCleverAdsBannerServiceErrorDomain" code:-999 userInfo:nil];
        if ([self.delegate respondsToSelector:@selector(bannerService:didFailToLoadMediumRectBannerWithError:)]) {
            [self.delegate bannerService:self didFailToLoadMediumRectBannerWithError:error];
        }
    }];
}

- (void)mediumRectBannerDidSuccessToLoad {
    [NSObject ls_performBlockOnMainQueue:^{
        //noting to do and also avoid multiple delegate calls for one event
        if (self.mediumRectBannerLoading == NO) {
            return;
        }
        self.mediumRectBannerLoading = NO;

        if ([self.delegate respondsToSelector:@selector(bannerServiceDidLoadMediumRectBanner:)]) {
            [self.delegate bannerServiceDidLoadMediumRectBanner:self];
        }
    }];
}

- (BOOL)isLoadingMediumRectangleBanner {
    return self.mediumRectBannerLoading;
}

- (void)unloadMediumRectangleBanner {
    self.mediumRectBannerLoading = NO;
    [self.mediumRectBanner removeFromSuperview];
    self.mediumRectBanner = nil;
}

- (UIView *)mediumRectangleBanner {
    return self.mediumRectBanner;
}

- (CGSize)mediumRectangleBannerSize {
    return CGSizeMake(300.0,250.0);
}

```